### PR TITLE
Update class name attribute to attr

### DIFF
--- a/dracula.css
+++ b/dracula.css
@@ -41,7 +41,7 @@
 .hljs-meta,
 .hljs-name,
 .hljs-type,
-.hljs-attribute,
+.hljs-attr,
 .hljs-symbol,
 .hljs-bullet,
 .hljs-addition,


### PR DESCRIPTION
The correct class for **attribute** is "**attr**".
ref:
https://github.com/isagalaev/highlight.js/tree/master/src/styles
https://github.com/isagalaev/highlight.js/blob/master/src/languages/xml.js#L14